### PR TITLE
fix(security): apply 3 dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "adobe-chal",
       "version": "0.1.0",
       "dependencies": {
+        "node-forge": "^1.4.0",
+        "path-to-regexp": "^0.1.13",
         "picomatch": "^4.0.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -7562,6 +7564,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11192,9 +11200,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -11650,9 +11658,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "node-forge": "^1.4.0",
+    "path-to-regexp": "^0.1.13",
     "picomatch": "^4.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -14,7 +16,7 @@
     "rollup": "^2.80.0",
     "serialize-javascript": "^7.0.3",
     "minimatch": "^10.2.3",
-    "node-forge": "^1.3.3",
+    "node-forge": "1.4.0",
     "nth-check": "^2.1.1",
     "postcss": "^8.4.31",
     "qs": "^6.14.1",


### PR DESCRIPTION
## Automated Security Fixes

- Alerts in this PR: 3

### Updated Dependencies
- path-to-regexp -> 0.1.13 (CVE-2026-4867)
- node-forge -> 1.4.0 (CVE-2026-33896)
- node-forge -> 1.4.0 (CVE-2026-33895)

### Dependabot Alerts
- https://github.com/reyesrico/adobe-chal/security/dependabot/79
- https://github.com/reyesrico/adobe-chal/security/dependabot/77
- https://github.com/reyesrico/adobe-chal/security/dependabot/76

## Validation
- Lint command executed
- Test command executed

## Quick Merge
Run: gh pr merge https://github.com/reyesrico/adobe-chal/pull/<new-pr-number> --auto --squash